### PR TITLE
fix for a too long filepath

### DIFF
--- a/-CODE-/Nat/SumecWSRCP-WebServerRemoteControlPanel/TechTests/ESP32WebServerAndAccessPoint/Test4_ESP32WebServer-NewRewrite/SumecWebServer/RewriteOfESP32WWJ/RewriteOfESP32WWJ.ino
+++ b/-CODE-/Nat/SumecWSRCP-WebServerRemoteControlPanel/TechTests/ESP32WebServerAndAccessPoint/Test4_ESP32WebServer-NewRewrite/SumecWebServer/RewriteOfESP32WWJ/RewriteOfESP32WWJ.ino
@@ -1,3 +1,6 @@
+/**
+ * WWJ means Webserver websocket json
+*/
 #include <WiFi.h>
 #include <WebServer.h>
 #include <WebSocketsServer.h>


### PR DESCRIPTION
filepaths longer then 256chars are a problem on older win10 versions and every previous windows release, this is an issue in some apps as well